### PR TITLE
Disable Style/NumericLiterals + Update RuboCop

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,29 +1,27 @@
 PATH
   remote: .
   specs:
-    rubocop-shiphawk (1.0.0)
-      rubocop (~> 0.64.0)
+    rubocop-shiphawk (1.2.0)
+      rubocop (~> 0.68.1)
 
 GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.0)
     jaro_winkler (1.5.2)
-    parallel (1.13.0)
-    parser (2.6.0.0)
+    parallel (1.17.0)
+    parser (2.6.3.0)
       ast (~> 2.4.0)
-    powerpack (0.1.2)
     rainbow (3.0.0)
-    rubocop (0.64.0)
+    rubocop (0.68.1)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
       parser (>= 2.5, != 2.5.1.1)
-      powerpack (~> 0.1)
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
-      unicode-display_width (~> 1.4.0)
+      unicode-display_width (>= 1.4.0, < 1.6)
     ruby-progressbar (1.10.0)
-    unicode-display_width (1.4.1)
+    unicode-display_width (1.5.0)
 
 PLATFORMS
   ruby

--- a/config/rubocop-shiphawk.yml
+++ b/config/rubocop-shiphawk.yml
@@ -32,6 +32,8 @@ Style/FrozenStringLiteralComment:
   Enabled: false
 Style/Lambda:
   Enabled: false
+Style/NumericLiterals:
+  Enabled: false
 
 Metrics/ClassLength:
   Enabled: false
@@ -51,7 +53,7 @@ Layout/AlignHash:
   Enabled: false
 Layout/EndAlignment:
   Enabled: false
-Layout/IndentHash:
+Layout/IndentFirstHashElement:
   EnforcedStyle: consistent
 
 Bundler/OrderedGems:

--- a/lib/rubocop/shiphawk/version.rb
+++ b/lib/rubocop/shiphawk/version.rb
@@ -2,6 +2,6 @@
 
 module RuboCop
   module ShipHawk
-    VERSION = '1.1.0'.freeze
+    VERSION = '1.2.0'.freeze
   end
 end

--- a/rubocop-shiphawk.gemspec
+++ b/rubocop-shiphawk.gemspec
@@ -14,5 +14,5 @@ Gem::Specification.new do |spec|
   spec.license               = 'MIT'
   spec.required_ruby_version = '>= 2.2.3'
 
-  spec.add_dependency 'rubocop', '~> 0.64.0'
+  spec.add_dependency 'rubocop', '~> 0.68.1'
 end


### PR DESCRIPTION
- Rubocop version changed.
- Style/NumericLiterals disabled because we are not supporting this style rule - in our main project we have the next statistic:

For ShipHawk-Dev project:
```
# Offense count: 47576
# Cop supports --auto-correct.
# Configuration parameters: Strict.
Style/NumericLiterals:
  MinDigits: 32
```